### PR TITLE
LMSDEV-3253: fix: Add library needed for mobile support

### DIFF
--- a/mobile/pluginfile.php
+++ b/mobile/pluginfile.php
@@ -36,6 +36,7 @@ require_once('../../../config.php');
 require_once($CFG->libdir . '/filelib.php');
 require_once($CFG->libdir . '/completionlib.php');
 require_once($CFG->dirroot . '/webservice/lib.php');
+require_once('../lib.php');
 
 // Allow CORS requests.
 header('Access-Control-Allow-Origin: *');


### PR DESCRIPTION
LMSDEV-3253:
A new function was trowning an error if an user try to download the certificate on mobile. Adding the lib.php where the library was seems to solve the issue. 