### PR TITLE
LMSDEV-3415: fix import error

### DIFF
--- a/classes/template.php
+++ b/classes/template.php
@@ -265,7 +265,7 @@ class template {
         }
 
         require_once($CFG->libdir . '/pdflib.php');
-        require_once('../lib.php');
+        require_once($CFG->dirroot . '/mod/customcert/lib.php');
 
         // Get the pages for the template, there should always be at least one page for each template.
         if ($pages = $DB->get_records('customcert_pages', array('templateid' => $this->id), 'sequence ASC')) {

--- a/mobile/pluginfile.php
+++ b/mobile/pluginfile.php
@@ -36,7 +36,7 @@ require_once('../../../config.php');
 require_once($CFG->libdir . '/filelib.php');
 require_once($CFG->libdir . '/completionlib.php');
 require_once($CFG->dirroot . '/webservice/lib.php');
-require_once('../lib.php');
+require_once($CFG->dirroot . '/mod/customcert/lib.php');
 
 // Allow CORS requests.
 header('Access-Control-Allow-Origin: *');


### PR DESCRIPTION
The import path was incorrect, was throwing errors like:

```[Thu Sep 15 15:13:37.624712 2022] [php7:notice] [pid 628770] [client ::1:57398] PHP Warning:  require_once(../lib.php): failed to open stream: No such file or directory in /var/www/aprende/mod/customcert/classes/template.php on line 268, referer: http://localhost/mod/customcert/edit.php?tid=56```