### PR TITLE
fix: LMSDEV-6741 Query current language instead of user language 

### DIFF
--- a/classes/template.php
+++ b/classes/template.php
@@ -275,12 +275,12 @@ class template {
             $customcert = $DB->get_record('customcert', ['templateid' => $this->id]);
 
             // I want to have my digital diplomas without having to change my preferred language.
-            $userlang = $USER->lang;
-            $forcelang = mod_customcert_force_current_language($customcert->language);  
+            $currentlang = current_language();
+            $forcelang = mod_customcert_force_current_language($customcert->language);
             if (!empty($forcelang)) {
                 // This is a failsafe -- if an exception triggers during the template rendering, this should still execute.
                 // Preventing a user from getting trapped with the wrong language.
-                \core_shutdown_manager::register_function('force_current_language', [$userlang]);
+                \core_shutdown_manager::register_function('force_current_language', [$currentlang]);
             }
 
             // If the template belongs to a certificate then we need to check what permissions we set for it.
@@ -336,8 +336,8 @@ class template {
             }
 
             // We restore original language.
-            if ($userlang != $customcert->language) {
-                mod_customcert_force_current_language($userlang);
+            if ($currentlang != $customcert->language) {
+                mod_customcert_force_current_language($currentlang);
             }
 
             if ($return) {

--- a/classes/template.php
+++ b/classes/template.php
@@ -275,12 +275,12 @@ class template {
             $customcert = $DB->get_record('customcert', ['templateid' => $this->id]);
 
             // I want to have my digital diplomas without having to change my preferred language.
-            $currentlang = current_language();
+            $initial_lang = current_language();
             $forcelang = mod_customcert_force_current_language($customcert->language);
             if (!empty($forcelang)) {
                 // This is a failsafe -- if an exception triggers during the template rendering, this should still execute.
                 // Preventing a user from getting trapped with the wrong language.
-                \core_shutdown_manager::register_function('force_current_language', [$currentlang]);
+                \core_shutdown_manager::register_function('force_current_language', [$initial_lang]);
             }
 
             // If the template belongs to a certificate then we need to check what permissions we set for it.
@@ -336,8 +336,8 @@ class template {
             }
 
             // We restore original language.
-            if ($currentlang != $customcert->language) {
-                mod_customcert_force_current_language($currentlang);
+            if ($initial_lang != $customcert->language) {
+                mod_customcert_force_current_language($initial_lang);
             }
 
             if ($return) {

--- a/lib.php
+++ b/lib.php
@@ -436,17 +436,15 @@ function mod_customcert_get_fontawesome_icon_map() {
  * @return bool
  */
 function mod_customcert_force_current_language($language): bool {
-    global $USER;
-
     $forced = false;
     if (empty($language)) {
         return $forced;
     }
 
     $activelangs = get_string_manager()->get_list_of_translations();
-    $userlang = $USER->lang;
+    $currentlang = current_language();
 
-    if (array_key_exists($language, $activelangs) && $language != $userlang) {
+    if (array_key_exists($language, $activelangs) && $language != $currentlang) {
         force_current_language($language);
         $forced = true;
     }


### PR DESCRIPTION
Reasoning for this change:

- We need $SESSION->forcelang to be set in order for the filter chain to
  work properly. This gets set by calling the moodle lib function
  force_current_language.
- mod_customcert was not calling force_current_language IF the user's
  language was equal to the certificate's forced language.
- This caused the following issue: A user with language en, in a session
  where the language was set to es_mx, viewing the
  forced-English-language certificate, would see a spanish section title
  instead of an English section title.
- As a fix, we should not worry about what the user's "preferred"
  language is when we're deciding whether to force a language. All we
  care about is the current session's language.
